### PR TITLE
Adapt memory query to support current NEST release

### DIFF
--- a/multiarea_model/simulation.py
+++ b/multiarea_model/simulation.py
@@ -311,7 +311,10 @@ class Simulation:
         """
         Use NEST's memory wrapper function to record used memory.
         """
-        mem = nest.sli_func('memory_thisjob')
+        try:
+            mem = nest.sli_func('memory_thisjob')
+        except AttributeError:
+            mem = nest.ll_api.sli_func('memory_thisjob')
         if isinstance(mem, dict):
             return mem['heap']
         else:


### PR DESCRIPTION
The API for getting the memory of a NEST job changed. The try except block first tries the old API. If it fails, it instead uses the newer one.