### PR TITLE
Fix external siegert neurons

### DIFF
--- a/multiarea_model/default_params.py
+++ b/multiarea_model/default_params.py
@@ -281,7 +281,7 @@ theory_params = {'neuron_params': neuron_params,
                  # The simulation time of the mean-field theory integration
                  'T': 50.,
                  # The time step of the mean-field theory integration
-                 'dt': 0.1,
+                 'dt': 0.01,
                  # Time interval for recording the trajectory of the mean-field calcuation
                  # If None, then the interval is set to dt
                  'rec_interval': None}

--- a/multiarea_model/theory.py
+++ b/multiarea_model/theory.py
@@ -78,13 +78,14 @@ class Theory:
                               'use_wfr': False,
                               'print_time': False,
                               'overwrite_files': True})
+
+        nest.SetDefaults('siegert_neuron', self.NP)
         # create neurons for external drive
         drive = nest.Create(
             'siegert_neuron', 1, params={'rate': rate_ext, 'mean': rate_ext})
 
         # create neurons representing populations
-        neurons = nest.Create(
-            'siegert_neuron', dim, params=self.NP)
+        neurons = nest.Create('siegert_neuron', dim)
         # external drive
         syn_dict = {'drift_factor': tau * np.array([K[:, -1] * J[:, -1]]).transpose(),
                     'diffusion_factor': tau * np.array([K[:, -1] * J[:, -1]**2]).transpose(),
@@ -132,7 +133,7 @@ class Theory:
         interval = self.params['rec_interval']
         if interval is None:
             interval = dt
-            
+
         multimeter = nest.Create('multimeter', params={'record_from': ['rate'],
                                                        'interval': interval,
                                                        'to_screen': False,


### PR DESCRIPTION
As @jarsi noted, the mean-field theory predictions are off in the current version with NEST >= 2.18. This is due to [a bugfix of the Siegert neuron in NEST](https://github.com/nest/nest-simulator/pull/1059) which causes the external drive to produce undesired rates because its parameters, in particular the threshold, were not set properly. Fix: Adjusting the default parameters of the `siegert_neuron`.

@jasperalbers, @jarsi and myself (in particular @jarsi!) tested the new implementation across different hardware (laptops, JURECA) & software (NEST & GSL versions) setups and got consistent results with the old code and old NEST versions.

During the process, we found that the theory does not converge in the fixed point for the parameters as in Fig. 5 of the dynamics paper with the current `dt`, thus I also reduced it to `dt=0.01` in the default parameters. 