### PR TITLE
Update reading in spikes from numpy arrays

### DIFF
--- a/multiarea_model/analysis.py
+++ b/multiarea_model/analysis.py
@@ -125,7 +125,7 @@ class Analysis:
                     fn = os.path.join(rec_dir,
                                       '.'.join((fp, 'npy')))
                     try:
-                        data[area][pop] = np.load(fn)
+                        data[area][pop] = np.load(fn, allow_pickle=True)
                     except FileNotFoundError:
                         if not hasattr(self, 'all_spikes'):
                             fp = '.'.join(('-'.join((self.simulation.label,


### PR DESCRIPTION
With more recent versions of numpy (changed in version 1.16.3, see [here](https://numpy.org/devdocs/reference/generated/numpy.load.html)) the default behavior of reading in numpy arrays changed from allow_pickle=True to allow_pickle=False. If we want to read in the processed spikes, which are stored in numpy arrays, across numpy versions we need to manually set it to True.

In general it is stated:
> Warning
> Loading files that contain object arrays uses the pickle module, which is not secure against erroneous or maliciously constructed data. Consider passing allow_pickle=False to load data that is known not to contain object arrays for the safer handling of untrusted sources.

Thus we should about another dataformat in the long run and consider this a temporary fix.