### PR TITLE
Enable use of NEST 3

### DIFF
--- a/multiarea_model/analysis.py
+++ b/multiarea_model/analysis.py
@@ -128,17 +128,23 @@ class Analysis:
                         data[area][pop] = np.load(fn, allow_pickle=True)
                     except FileNotFoundError:
                         if not hasattr(self, 'all_spikes'):
+                            csv_args = {'names': columns,
+                                        'sep': '\t',
+                                        'index_col': False}
+                            if self.network.params['USING_NEST_3']:
+                                csv_args.update({'skiprows': 3})
+                                file_ending = 'dat'
+                            else:
+                                file_ending = 'gdf'
                             fp = '.'.join(('-'.join((self.simulation.label,
                                                      self.simulation.params[
                                                          'recording_dict'][d]['label'],
                                                      '*')),
-                                           'gdf'))
+                                           file_ending))
                             files = glob.glob(os.path.join(rec_dir, fp))
                             dat = pd.DataFrame(columns=columns)
                             for f in files:
-                                dat = dat.append(pd.read_csv(f,
-                                                             names=columns, sep='\t',
-                                                             index_col=False),
+                                dat = dat.append(pd.read_csv(f, **csv_args),
                                                  ignore_index=True)
                             self.all_spikes = dat
                         print(area, pop)

--- a/multiarea_model/data_multiarea/VisualCortex_Data.py
+++ b/multiarea_model/data_multiarea/VisualCortex_Data.py
@@ -5,7 +5,7 @@ VisualCortexData
 This script provides the function process_raw_data which fulfills two
 tasks:
 1) Load the experimental data from the raw data files stored in
-   raw_data/ and stores it to viscorted_raw_data.json.
+   raw_data/ and stores it to viscortex_raw_data.json.
 2) Process the data to derive complete sets of FLN, SLN, neuronal
    densities and laminar thicknesses and store these values to
    viscortex_processed_data.json.

--- a/multiarea_model/default_params.py
+++ b/multiarea_model/default_params.py
@@ -14,6 +14,7 @@ Maximilian Schmidt
 from config import base_path
 import json
 import os
+import nest
 
 import numpy as np
 
@@ -62,7 +63,11 @@ network_params = {
     'K_scaling': 1.,
     # Absolute path to the file holding full-scale rates for scaling
     # synaptic weights
-    'fullscale_rates': None
+    'fullscale_rates': None,
+    # Check whether NEST 2 or 3 is used. No straight way of checking this is
+    # available. But PrintNetwork was removed in NEST 3, so checking for its
+    # existence should suffice.
+    'USING_NEST_3': 'PrintNetwork' not in dir(nest)
 }
 
 
@@ -246,18 +251,22 @@ recording_dict = {
     # Parameters for the spike detectors
     'spike_dict': {
         'label': 'spikes',
-        'withtime': True,
-        'record_to': ['file'],
         'start': 0.},
     # Parameters for the voltmeters
     'vm_dict': {
         'label': 'vm',
         'start': 0.,
         'stop': 1000.,
-        'interval': 0.1,
-        'withtime': True,
-        'record_to': ['file']}
+        'interval': 0.1}
     }
+if network_params['USING_NEST_3']:
+    recording_dict['spike_dict'].update({'record_to': 'ascii'})
+    recording_dict['vm_dict'].update({'record_to': 'ascii'})
+else:
+    recording_dict['spike_dict'].update({'withtime': True,
+                                         'record_to': ['file']})
+    recording_dict['vm_dict'].update({'withtime': True,
+                                      'record_to': ['file']})
 sim_params.update({'recording_dict': recording_dict})
 
 """

--- a/multiarea_model/simulation.py
+++ b/multiarea_model/simulation.py
@@ -170,7 +170,10 @@ class Simulation:
         - spike detector
         - voltmeter
         """
-        self.spike_detector = nest.Create('spike_detector')
+        try:
+            self.spike_detector = nest.Create('spike_recorder')
+        except:
+            self.spike_detector = nest.Create('spike_detector')
         status_dict = deepcopy(self.params['recording_dict']['spike_dict'])
         label = '-'.join((self.label,
                           status_dict['label']))

--- a/multiarea_model/simulation.py
+++ b/multiarea_model/simulation.py
@@ -170,7 +170,7 @@ class Simulation:
         - spike detector
         - voltmeter
         """
-        self.spike_detector = nest.Create('spike_detector', 1)
+        self.spike_detector = nest.Create('spike_detector')
         status_dict = deepcopy(self.params['recording_dict']['spike_dict'])
         label = '-'.join((self.label,
                           status_dict['label']))
@@ -347,10 +347,16 @@ class Simulation:
                                'network_gids.txt'), 'w') as f:
             for area in self.areas:
                 for pop in self.network.structure[area.name]:
+                    if self.network.params['USING_NEST_3']:
+                        first_id = area.gids[pop][0].get()['global_id']
+                        last_id = area.gids[pop][-1].get()['global_id']
+                    else:
+                        first_id = area.gids[pop][0]
+                        last_id = area.gids[pop][1]
                     f.write("{area},{pop},{g0},{g1}\n".format(area=area.name,
                                                               pop=pop,
-                                                              g0=area.gids[pop][0],
-                                                              g1=area.gids[pop][1]))
+                                                              g0=first_id,
+                                                              g1=last_id))
 
     def register_runtime(self):
         if sumatra_found:
@@ -443,31 +449,39 @@ class Area:
                 I_e += DC
             nest.SetStatus(gid, {'I_e': I_e})
 
-            # Store first and last GID of each population
-            self.gids[pop] = (gid[0], gid[-1])
+            if self.network.params['USING_NEST_3']:
+                # Store GIDCollection of each population
+                self.gids[pop] = gid
+            else:
+                # Store first and last GID of each population
+                self.gids[pop] = (gid[0], gid[-1])
 
             # Initialize membrane potentials
             # This could also be done after creating all areas, which
             # might yield better performance. Has to be tested.
-            for t in np.arange(nest.GetKernelStatus('local_num_threads')):
-                local_nodes = np.array(nest.GetNodes(
-                    [0], {
-                        'model': self.network.params['neuron_params']['neuron_model'],
-                        'thread': t
-                    }, local_only=True
-                )[0])
-                local_nodes_pop = local_nodes[(np.logical_and(local_nodes >= gid[0],
-                                                              local_nodes <= gid[-1]))]
-                if len(local_nodes_pop) > 0:
-                    vp = nest.GetStatus([local_nodes_pop[0]], 'vp')[0]
-                    # vp is the same for all local nodes on the same thread
-                    nest.SetStatus(
-                        list(local_nodes_pop), 'V_m', self.simulation.pyrngs[vp].normal(
-                            self.network.params['neuron_params']['V0_mean'],
-                            self.network.params['neuron_params']['V0_sd'],
-                            len(local_nodes_pop))
-                            )
-                    self.num_local_nodes += len(local_nodes_pop)
+            if self.network.params['USING_NEST_3']:
+                gid.V_m = nest.random.normal(self.network.params['neuron_params']['V0_mean'],
+                                             self.network.params['neuron_params']['V0_sd'])
+            else:
+                for t in np.arange(nest.GetKernelStatus('local_num_threads')):
+                    local_nodes = np.array(nest.GetNodes(
+                        [0], {
+                            'model': self.network.params['neuron_params']['neuron_model'],
+                            'thread': t
+                        }, local_only=True
+                    )[0])
+                    local_nodes_pop = local_nodes[(np.logical_and(local_nodes >= gid[0],
+                                                                  local_nodes <= gid[-1]))]
+                    if len(local_nodes_pop) > 0:
+                        vp = nest.GetStatus([local_nodes_pop[0]], 'vp')[0]
+                        # vp is the same for all local nodes on the same thread
+                        nest.SetStatus(
+                            list(local_nodes_pop), 'V_m', self.simulation.pyrngs[vp].normal(
+                                self.network.params['neuron_params']['V0_mean'],
+                                self.network.params['neuron_params']['V0_sd'],
+                                len(local_nodes_pop))
+                                )
+                        self.num_local_nodes += len(local_nodes_pop)
 
     def connect_populations(self):
         """
@@ -482,28 +496,41 @@ class Area:
             for pop in self.populations:
                 # Always record spikes from all neurons to get correct
                 # statistics
-                nest.Connect(tuple(range(self.gids[pop][0], self.gids[pop][1] + 1)),
-                             self.simulation.spike_detector)
+                if self.network.params['USING_NEST_3']:
+                    nest.Connect(self.gids[pop],
+                                 self.simulation.spike_detector)
+                else:
+                    nest.Connect(tuple(range(self.gids[pop][0], self.gids[pop][1] + 1)),
+                                 self.simulation.spike_detector)
 
         if self.simulation.params['recording_dict']['record_vm']:
             for pop in self.populations:
                 nrec = int(self.simulation.params['recording_dict']['Nrec_vm_fraction'] *
                            self.neuron_numbers[pop])
-                nest.Connect(self.simulation.voltmeter,
-                             tuple(range(self.gids[pop][0], self.gids[pop][0] + nrec + 1)))
+                if self.network.params['USING_NEST_3']:
+                    nest.Connect(self.simulation.voltmeter,
+                                 self.gids[pop][:nrec])
+                else:
+                    nest.Connect(self.simulation.voltmeter,
+                                 tuple(range(self.gids[pop][0], self.gids[pop][0] + nrec + 1)))
         if self.network.params['input_params']['poisson_input']:
             self.poisson_generators = []
             for pop in self.populations:
                 K_ext = self.external_synapses[pop]
                 W_ext = self.network.W[self.name][pop]['external']['external']
-                pg = nest.Create('poisson_generator', 1)
+                pg = nest.Create('poisson_generator')
                 nest.SetStatus(
                     pg, {'rate': self.network.params['input_params']['rate_ext'] * K_ext})
                 syn_spec = {'weight': W_ext}
-                nest.Connect(pg,
-                             tuple(
-                                 range(self.gids[pop][0], self.gids[pop][1] + 1)),
-                             syn_spec=syn_spec)
+                if self.network.params['USING_NEST_3']:
+                    nest.Connect(pg,
+                                 self.gids[pop],
+                                 syn_spec=syn_spec)
+                else:
+                    nest.Connect(pg,
+                                 tuple(
+                                     range(self.gids[pop][0], self.gids[pop][1] + 1)),
+                                 syn_spec=syn_spec)
                 self.poisson_generators.append(pg[0])
 
     def create_additional_input(self, input_type, source_area_name, cc_input):
@@ -543,7 +570,7 @@ class Area:
                 K = synapses[pop][source_pop] / self.neuron_numbers[pop]
 
                 if input_type == 'het_current_nonstat':
-                    curr_gen = nest.Create('step_current_generator', 1)
+                    curr_gen = nest.Create('step_current_generator')
                     dt = self.simulation.params['dt']
                     T = self.simulation.params['t_sim']
                     assert(len(cc_input[source_pop]) == int(T))
@@ -551,17 +578,27 @@ class Area:
                                               'amplitude_times': np.arange(dt,
                                                                            T + dt,
                                                                            1.)})
-                    nest.Connect(curr_gen,
-                                 tuple(
-                                     range(self.gids[pop][0], self.gids[pop][1] + 1)),
-                                 syn_spec=syn_spec)
+                    if self.network.params['USING_NEST_3']:
+                        nest.Connect(curr_gen,
+                                     self.gids[pop],
+                                     syn_spec=syn_spec)
+                    else:
+                        nest.Connect(curr_gen,
+                                     tuple(
+                                         range(self.gids[pop][0], self.gids[pop][1] + 1)),
+                                     syn_spec=syn_spec)
                 elif 'poisson_stat' in input_type:  # hom. and het. poisson lead here
-                    pg = nest.Create('poisson_generator', 1)
+                    pg = nest.Create('poisson_generator')
                     nest.SetStatus(pg, {'rate': K * cc_input[source_pop]})
-                    nest.Connect(pg,
-                                 tuple(
-                                     range(self.gids[pop][0], self.gids[pop][1] + 1)),
-                                 syn_spec=syn_spec)
+                    if self.network.params['USING_NEST_3']:
+                        nest.Connect(pg,
+                                     self.gids[pop],
+                                     syn_spec=syn_spec)
+                    else:
+                        nest.Connect(pg,
+                                     tuple(
+                                         range(self.gids[pop][0], self.gids[pop][1] + 1)),
+                                     syn_spec=syn_spec)
 
 
 def connect(simulation,
@@ -620,9 +657,15 @@ def connect(simulation,
                         'delay': syn_delay,
                         'model': 'static_synapse'}
 
-            nest.Connect(tuple(range(source_area.gids[source][0],
-                                     source_area.gids[source][1] + 1)),
-                         tuple(range(target_area.gids[target][0],
-                                     target_area.gids[target][1] + 1)),
-                         conn_spec,
-                         syn_spec)
+            if network.params['USING_NEST_3']:
+                nest.Connect(source_area.gids[source],
+                             target_area.gids[target],
+                             conn_spec,
+                             syn_spec)
+            else:
+                nest.Connect(tuple(range(source_area.gids[source][0],
+                                         source_area.gids[source][1] + 1)),
+                             tuple(range(target_area.gids[target][0],
+                                         target_area.gids[target][1] + 1)),
+                             conn_spec,
+                             syn_spec)


### PR DESCRIPTION
With the upcoming release of NEST 3 some function calls change a little bit. This PR addresses these changes and guarantees compatibility with both NEST 2 and NEST 3. At the beginning of a simulation it is determined whether NEST 2 or 3 features should be used. Based on this the parts in question are run accordingly.