### PR TITLE
Update multiarea_helpers.py

### DIFF
--- a/multiarea_model/multiarea_helpers.py
+++ b/multiarea_model/multiarea_helpers.py
@@ -229,7 +229,7 @@ def matrix_to_dict(m, area_list, structure, external=None):
             x = x.reshape((8, 8))
         for i, pop in enumerate(population_list):
             for j, pop2 in enumerate(population_list):
-                if x[i][j] < 1e-20:
+                if np.isclose(0., x[i][j]):
                     x[i][j] = 0.
                 dic[area][pop][area2][pop2] = x[i][j]
     if external is not None:


### PR DESCRIPTION
If either N_scaling or K_scaling is different from 1, some quantities are scaled. Eg. the number of neurons, the number of synapses, the indegree, the weights... 

The initial dictionaries are first converted to matrices. Then the scaling is performed using the matrices. After that the matrices are converted back to dictionaries again. For the conversion the `matrix_to_dict()` function is used. While recreating the dictionaries a check whether a given value is less than 1e-20 is performed. Most of the matrices to be scaled contain only positive numbers. Only the weights dictionary / matrix contains negative numbers stemming from inhibitory connections. Using the comparison as is leads to all inhibitory weights being set to 0 if any scaling is used.

I think this comparison should be used to only set any value close to 0 to actual 0, instead of setting all values slightly above 0 to 0.