### PR TITLE
Remove Harden Runner

### DIFF
--- a/.github/workflows/ebrains-push.yml
+++ b/.github/workflows/ebrains-push.yml
@@ -9,12 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'INM-6' }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          egress-policy: audit
-          disable-telemetry: true
-
       - name: sycnmaster
         uses: wei/git-sync@55c6b63b4f21607da0e9877ca9b4d11a29fc6d83
         with:


### PR DESCRIPTION
This PR removes the Harden Runner used in the workflow ebrains-push.yml to follow security rules set for repositories of INM-6.