### PR TITLE
Correct the areas order in the plot of functional connectivity 

### DIFF
--- a/figures/MAM2EBRAINS/M2E_firing_rate.py
+++ b/figures/MAM2EBRAINS/M2E_firing_rate.py
@@ -97,4 +97,5 @@ def plot_firing_rate_over_areas(M, data_path):
     ax.set_ylabel('Area', size=13)
     ax.set_xlabel('Time (ms)', size=13)
 
-    pl.colorbar(im)
+    cbar = pl.colorbar(im)
+    cbar.set_label('spikes/s', fontsize=13)

--- a/figures/MAM2EBRAINS/M2E_visualize_fc.py
+++ b/figures/MAM2EBRAINS/M2E_visualize_fc.py
@@ -99,13 +99,13 @@ def visualize_fc(M, data_path):
     """
     Figure layout
     """
-    fig = pl.figure(figsize=(10, 4))
+    fig = pl.figure(figsize=(9, 4))
     fig.suptitle('Simulated functional connectivity (left) and FC of macaque resting-state fMRI', 
-                 fontsize=17, x=0.5, y=1.1)
+                 fontsize=17, x=0.53, y=1.15)
     axes = {}
     gs1 = gridspec.GridSpec(1, 2)
     gs1.update(left=0.05, right=0.95, top=1,
-               bottom=0, wspace=0.3, hspace=0)
+               bottom=0.3, wspace=0.3, hspace=0)
     axes['A'] = pl.subplot(gs1[:1, :1])
     axes['B'] = pl.subplot(gs1[:1, 1:2])
 
@@ -188,9 +188,13 @@ def visualize_fc(M, data_path):
     ax = axes['B']
     matrix_plot(M, ax, zero_diagonal(exp_FC),
                 part_sim_index, 1., pos=(0, 0))
-
+        
     areas = np.array(M.area_list)[part_sim_index]
     area_string = areas[0]
     for area in areas[1:]:
         area_string += ' '
         area_string += area
+
+    pl.text(0.00, 0.15, r'Order of cortical areas:', transform=fig.transFigure, fontsize=13, fontweight='bold')
+    pl.text(0.00, 0.1, area_string,
+        transform=fig.transFigure, fontsize=11)

--- a/figures/MAM2EBRAINS/M2E_visualize_time_ave_pop_rates.py
+++ b/figures/MAM2EBRAINS/M2E_visualize_time_ave_pop_rates.py
@@ -67,7 +67,8 @@ def plot_time_averaged_population_rates(M, data_path, area_list=None, **keywords
             if masked_matrix.mask[i, j]:
                 ax.text(j + 0.5, i + 0.5, 'X', va='center', ha='center', color='black', fontsize=23)
 
-    plt.colorbar(im)
+    cbar = plt.colorbar(im)
+    cbar.set_label('spikes/s', fontsize=13)
 
     if 'output' in keywords:
         plt.savefig(os.path.join(M.output_dir, '{}_rates.{}'.format(M.simulation.label,

--- a/multi-area-model.ipynb
+++ b/multi-area-model.ipynb
@@ -658,15 +658,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "678741b2-6dfa-4f1d-b4d8-ccd84f104767",
-   "metadata": {},
-   "source": [
-    "**Order of cortical areas**: <br>\n",
-    "V1, V2, VP, V3, V3A, MT, V4t, V4, VOT, MSTd, PIP, PO, DP, MIP, MDP, VIP, LIP, PITv, PITd, MSTl, CITv, CITd, FEF, TF, AITv, FST, 7a, STPp, STPa, 46, AITd, TH"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b4b25621-618d-4594-8cf7-9b9002837d69",


### PR DESCRIPTION
This pull request corrects the order of areas displayed in the plot of functional connectivity. Besides, it adds unit labels for the color bar of 2 plots.