### PR TITLE
Fix run_example scripts

### DIFF
--- a/run_example_downscaled.py
+++ b/run_example_downscaled.py
@@ -16,9 +16,11 @@ d = {}
 conn_params = {'replace_non_simulated_areas': 'het_poisson_stat',
                'cc_weights_factor': 1.0, # run model in Ground State
                'cc_weights_I_factor': 1.0}
+
 network_params = {'N_scaling': 0.01,
                   'K_scaling': 0.01,
-                  'fullscale_rates': os.path.join(base_path, 'tests/fullscale_rates.json')}
+                  'fullscale_rates': os.path.join(base_path, 'tests/fullscale_rates.json'),
+                  'connection_params': conn_params}
 
 sim_params = {'t_sim': 2000.,
               'num_processes': 1,

--- a/run_example_fullscale.py
+++ b/run_example_fullscale.py
@@ -21,8 +21,12 @@ resources, for instance on a compute cluster.
 """
 d = {}
 
+conn_params = {'cc_weights_factor': 1.0, # run model in Ground State
+               'cc_weights_I_factor': 1.0}
+
 network_params = {'N_scaling': 1.,
-                  'K_scaling': 1.}
+                  'K_scaling': 1.,
+                  'connection_params': conn_params}
 
 sim_params = {'t_sim': 2000.,
               'num_processes': 720,


### PR DESCRIPTION
Both example scripts (fullscale and downscaled) did not produce the ground state mode, as it was indicated in the scripts This PR fixes this. 

The default parameters are set to the metastable state, as written in the default_params.py and README.